### PR TITLE
Added report issue button for fatal errors

### DIFF
--- a/customizer.html
+++ b/customizer.html
@@ -75,7 +75,7 @@
             isFatal = isFatal || false;
             if (isFatal) {
                 $(".ui.action.input").remove();
-                $(".ui.main.container").addClass("fatalError").prepend('<div class="ui negative message"><div class="header">' + title + '</div><p>' + content + '</p></div>');
+                $(".ui.main.container").addClass("fatalError").prepend('<div class="ui negative message"><div class="header">' + title + '</div><p>' + content + '</p><p><a href="https://github.com/just-install/just-install/issues/new?title=Just-install%20customizer%20fatal%20error&body=' + encodeURIComponent("REPLACE THIS TEXT WITH A DESCRIPTION OF THE ERROR\n\n\nError message:\n````\n" + content + "\n````") + '">Report an issue</a></p></div>');
             } else {
                 $(".ui.main.container").prepend('<div class="ui negative message"><i class="close icon"></i><div class="header">' + title + '</div><p>' + content + '</p></div>').find(".close").click(function () {
                     $(this).closest('.message').transition('fade');


### PR DESCRIPTION
I have added a prefilled report issue button for fatal errors. [This](https://github.com/just-install/just-install/issues/new?title=Just-install%20customizer%20fatal%20error&body=REPLACE%20THIS%20TEXT%20WITH%20A%20DESCRIPTION%20OF%20THE%20ERROR%0A%0A%0AError%20message%3A%0A%60%60%60%60%0AThe%20file%20just-install.exe%20does%20not%20exist%20in%20the%20same%20folder%20as%20this%20webpage.%20For%20this%20tool%20to%20work%2C%20please%20place%20just-install.exe%20in%20http%3A%2F%2Flocalhost%3A8000%2F%20and%20reload%20this%20page.%0A%60%60%60%60) is an example link which will be placed on the bottom of the error message.

