### PR TITLE
Fix zip extraction

### DIFF
--- a/pkg/justinstall/util.go
+++ b/pkg/justinstall/util.go
@@ -242,6 +242,7 @@ func extractZip(path string, extractTo string) {
 		if zipFile.FileInfo().IsDir() {
 			os.MkdirAll(destinationPath, zipFile.Mode())
 		} else {
+			os.MkdirAll(filepath.Dir(destinationPath), 0777)
 			// Create destination file
 			dest, err := os.Create(destinationPath)
 			if err != nil {

--- a/pkg/justinstall/util.go
+++ b/pkg/justinstall/util.go
@@ -248,17 +248,18 @@ func extractZip(path string, extractTo string) {
 			if err != nil {
 				log.Fatalln("Unable to create destination:", destinationPath)
 			}
-			defer dest.Close()
 
 			// Open input stream
 			source, err := zipFile.Open()
 			if err != nil {
+				dest.Close()
 				log.Fatalln("Unable to open input ZIP file:", zipFile.Name)
 			}
-			defer source.Close()
 
 			// Extract file
 			io.Copy(dest, source)
+			dest.Close()
+			source.Close()
 		}
 	}
 }


### PR DESCRIPTION
This fixes #251 by creating the output directory before extracting a file from a zip file, as the entries may be out of order in the zip.

This also prevents crashes when extracting large numbers of files by closing file descriptors as soon as they are no longer needed, instead of after all files have been extracted.