### PR TITLE
Readd installer kind zip

### DIFF
--- a/pkg/justinstall/registry.go
+++ b/pkg/justinstall/registry.go
@@ -267,6 +267,8 @@ func (e *RegistryEntry) install(path string) error {
 		}
 
 		return cmd.Run(args...)
+	} else if e.Installer.Kind == "zip" {
+		return installer.ExtractZIP(path, e.destination())
 	}
 
 	installerType := installer.InstallerType(e.Installer.Kind)


### PR DESCRIPTION
@lvillani probably accidentally removed it in https://github.com/just-install/just-install/commit/5e332834934f7838a6fc0566df64b39c877918b8. In https://github.com/just-install/just-install/issues/310 it was decided that `zip` installers will continue to be supported by _just-install_.