### PR TITLE
Change version info to last commit for unstable builds

### DIFF
--- a/make.go
+++ b/make.go
@@ -110,7 +110,13 @@ func deploy() {
 
 func getVersion() string {
 	if !isStableBuild() {
-		return "unstable"
+		cmd := exec.Command("git", "rev-parse", "--short", "HEAD")
+		commitShort, err := cmd.Output()
+		if err != nil {
+			log.Fatalln("cannot get last commit:", err)
+		}
+
+		return string(commitShort[:len(commitShort)-1])
 	}
 
 	f, err := dry.FileGetJSON(".releng.json")


### PR DESCRIPTION
`unstable` in the version string isn't very useful. When using an unstable build one might forget when and from which branch it was built making it very difficult to identify issues or missing features. I propose to set the version to the last commit for unstable builds to make it possible to identify from which code the unstable binary was built.